### PR TITLE
fix(beefy): withdraw shortcut decimals

### DIFF
--- a/src/apps/beefy/positions.ts
+++ b/src/apps/beefy/positions.ts
@@ -157,7 +157,7 @@ const beefyAppTokenDefinition = ({
           tokenDecimals:
             tokensByTokenId[
               getTokenId({
-                address: vault.earnedTokenAddress,
+                address: vault.tokenAddress, // use tokenAddress instead of earnedTokenAddress to avoid unmatching decimals
                 networkId,
               })
             ].decimals,


### PR DESCRIPTION
### Description

Get decimals for the withdraw shortcut from the main token instead of the earned token, since the earned token decimals doesn't match the main token ones.

For instance:

Morpho "Seamless USDC" token -- doesn't match USDC decimals:
https://basescan.org/address/0xf3c4db91f380963e00caa4ac1f0508259c9a3d3a#readContract#F6

Compound USDC token -- doesn't match USDC decimals:
https://basescan.org/address/0xeF6ED674486E54507d0f711C0d388BD8a1552E6F#readContract#F6

However, the balance is stored in main token decimals.

Using earned token decimals leads to inability to withdraw funds using shortcut, throwing the error:

> Fail with error 'ERC20: burn amount exceeds balance' 

([example transaction](https://basescan.org/tx/0x427a181c5f63e41797f34520dc6b60615be406a1dfc8cf63dd1a1472d4338341) trying to withdraw 0.5 USDC)

Context:
https://valora-app.slack.com/archives/C08HSR018CA/p1756464724011109

### Related issues

Related to ENG-623