### PR TITLE
fix(beefy): convert token amount to shares amount for withdrawal

### DIFF
--- a/src/utils/bigInt.ts
+++ b/src/utils/bigInt.ts
@@ -28,5 +28,5 @@ export const max = (a: bigint, b: bigint): bigint => (a > b ? a : b)
  * @returns The ceiling of the division result
  */
 export const ceilDiv = (dividend: bigint, divisor: bigint): bigint => {
-  return dividend / divisor + (dividend % divisor === 0n ? 0n : 1n)
+  return (dividend + divisor - 1n) / divisor
 }

--- a/src/utils/bigInt.ts
+++ b/src/utils/bigInt.ts
@@ -1,0 +1,32 @@
+/**
+ * Utility functions for BigInt operations
+ *
+ * Note: JavaScript's built-in Math.min() and Math.max() don't support BigInt values
+ * and will throw a TypeError if used with them.
+ */
+
+/**
+ * Returns the smaller of two BigInt values
+ * @param a First BigInt value
+ * @param b Second BigInt value
+ * @returns The smaller of the two values
+ */
+export const min = (a: bigint, b: bigint): bigint => (a < b ? a : b)
+
+/**
+ * Returns the larger of two BigInt values
+ * @param a First BigInt value
+ * @param b Second BigInt value
+ * @returns The larger of the two values
+ */
+export const max = (a: bigint, b: bigint): bigint => (a > b ? a : b)
+
+/**
+ * Simulates ceiling division for BigInt values
+ * @param dividend The number to be divided
+ * @param divisor The number to divide by
+ * @returns The ceiling of the division result
+ */
+export const ceilDiv = (dividend: bigint, divisor: bigint): bigint => {
+  return dividend / divisor + (dividend % divisor === 0n ? 0n : 1n)
+}


### PR DESCRIPTION
### Description

Beefy Valut V7 expects the amount of shares, and not the amount of underlying token, to be provided for the `withdraw()` method. This requires us to convert the token amount to a shares amount inside the shortcut to ensure the correct amount is withdrawn.

* [docs](https://docs.beefy.finance/developer-documentation/vault-contract#withdraw)
* [contract code](https://github.com/beefyfinance/beefy-contracts/blob/5b3f00395d70e65f3f246dce30f1219254e8d04d/contracts/BIFI/vaults/BeefyVaultV7.sol#L139-L155)

### TODO

There is clearly a race condition between reading the contract data and executing the withdrawal, which may affect the precision of the operation. We might want to use a helper contract to encapsulate all readings within a single transaction.
