### PR TITLE
chore: cache `getTokensInfoWithPrices`

### DIFF
--- a/src/runtime/getPositions.ts
+++ b/src/runtime/getPositions.ts
@@ -52,7 +52,7 @@ type AppPositionDefinition = PositionDefinition & {
 }
 
 const baseTokensInfoCache = new LRUCache<string, TokensInfo>({
-  max: 10, // Keep up to 10 different URL combinations
+  max: 50, // Should be enough for supported networks combinations for now
   ttl: 5 * 1000, // 5 seconds,
   allowStale: true, // allows stale-while-revalidate behavior
   fetchMethod: async (url: string) => {

--- a/src/runtime/getPositions.ts
+++ b/src/runtime/getPositions.ts
@@ -54,7 +54,7 @@ type AppPositionDefinition = PositionDefinition & {
 const baseTokensInfoCache = new LRUCache<string, TokensInfo>({
   max: 50, // Should be enough for supported networks combinations for now
   ttl: 5 * 1000, // 5 seconds,
-  allowStale: true, // allows stale-while-revalidate behavior
+  allowStale: true, // allow stale-while-revalidate behavior
   fetchMethod: async (url: string) => {
     // Get base tokens
     const data = await got.get(url).json<Record<string, RawTokenInfo>>()

--- a/src/runtime/getPositions.ts
+++ b/src/runtime/getPositions.ts
@@ -79,7 +79,7 @@ export async function getBaseTokensInfo(
   networkIds: NetworkId[] = [],
 ): Promise<TokensInfo> {
   const url = networkIds.length
-    ? `${getTokensInfoUrl}?networkIds=${networkIds.join(',')}`
+    ? `${getTokensInfoUrl}?networkIds=${[...networkIds].sort().join(',')}`
     : getTokensInfoUrl
 
   const result = await baseTokensInfoCache.fetch(url)


### PR DESCRIPTION
### Description

Cache base tokens info for 5 seconds, while allowing stale-while-revalidate behavior.

This will ensure:
1. Data is always fresh. 5 second lag seems negligible, given the direct request may take 1-3 seconds
2. Data is retrieved fast

